### PR TITLE
Ignore click events on non-slide elements

### DIFF
--- a/a-presentation.html
+++ b/a-presentation.html
@@ -81,6 +81,9 @@
         }, true);
 
         this.addEventListener('click', function(event) {
+          if (event.target.tagName.toLowerCase() !== 'a-slide') {
+            return;
+          }
           if (event.clientX > (screen.width / 2)) {
             this.next();
           } else {


### PR DESCRIPTION
Any click was triggering the slide transitions. This caused clicks on for example a `<paper-input>` to trigger the next/previous slide.
