### PR TITLE
Allow suppression of animations for bullet lists

### DIFF
--- a/a-presentation.html
+++ b/a-presentation.html
@@ -96,8 +96,13 @@
 
       next: function() {
         if (this.animated) {
-          this._entryAnimation = 'slide-from-right-animation';
-          this._exitAnimation = 'slide-left-animation';
+          if (this.$.pages.selectedItem.suppressNextAnimation) {
+            this._entryAnimation = '';
+            this._exitAnimation = '';
+          } else {
+            this._entryAnimation = 'slide-from-right-animation';
+            this._exitAnimation = 'slide-left-animation';
+          }
         }
 
         // Don't go past the end.
@@ -109,8 +114,13 @@
 
       previous: function() {
         if (this.animated) {
-          this._entryAnimation = 'slide-from-left-animation';
-          this._exitAnimation = 'slide-right-animation';
+          if (this.$.pages.selectedItem.suppressPreviousAnimation) {
+            this._entryAnimation = '';
+            this._exitAnimation = '';
+          } else {
+            this._entryAnimation = 'slide-from-left-animation';
+            this._exitAnimation = 'slide-right-animation';
+          }
         }
 
         // Don't go past the beginning.

--- a/a-slide.html
+++ b/a-slide.html
@@ -81,7 +81,17 @@
 
   <script>
     Polymer({
-      is: 'a-slide'
+      is: 'a-slide',
+      properties: {
+        suppressNextAnimation: {
+          type: Boolean,
+          value: false
+        },
+        suppressPreviousAnimation: {
+          type: Boolean,
+          value: false
+        }
+      }
     });
   </script>
 </dom-module>


### PR DESCRIPTION
For bullet list with fading in bullets, animations should be suppressed to prevent animation clutter. This PR adds control with the two new `a-slide` properties to suppress the animations. Example:

``` html
<a-slide class="theme-blue" align-center suppress-next-animation>
      <div class="title">Communication</div>
      <div class="subtitle">
        <ol>
          <li>Properties</li>
          <li class="invisible">Events</li>
          <li class="invisible">Methods</li>
        </ol>
      </div>
    </a-slide>

    <a-slide class="theme-blue" align-center suppress-next-animation suppress-previous-animation>
      <div class="title">Communication</div>
      <div class="subtitle">
        <ol>
          <li>Properties</li>
          <li>Events</li>
          <li class="invisible">Methods</li>
        </ol>
      </div>
    </a-slide>

    <a-slide class="theme-blue" align-center suppress-previous-animation>
      <div class="title">Communication</div>
      <div class="subtitle">
        <ol>
          <li>Properties</li>
          <li>Events</li>
          <li>Methods</li>
        </ol>
      </div>
    </a-slide>
```
